### PR TITLE
tests: cobertura ~90% (UV)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,13 @@
+[run]
+branch = True
+source =
+    src
+    main.py
+omit =
+    src/DiscordBot.py
+
+[report]
+show_missing = True
+exclude_lines =
+    if __name__ == .__main__.: 
+    pragma: no cover

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI (UV + Pytest)
+
+on:
+  push:
+    branches: [ main, "feat/**", "fix/**", "chore/**", "test/**" ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install UV
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Create venv and install dependencies
+        run: |
+          uv venv .venv
+          . .venv/bin/activate
+          uv pip install -r requirements.txt
+          uv pip install pytest-cov
+
+      - name: Run tests
+        run: |
+          . .venv/bin/activate
+          uv run -- pytest -q
+
+      - name: Coverage (term + XML)
+        run: |
+          . .venv/bin/activate
+          uv run -- pytest --cov=src --cov=main.py --cov-report=xml --cov-report=term-missing
+
+      - name: Upload coverage.xml
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml

--- a/tests/test_admin_panel.py
+++ b/tests/test_admin_panel.py
@@ -1,0 +1,39 @@
+import os
+import pytest
+from unittest.mock import patch
+
+
+class TestAdminPanel:
+    def test_env_load_and_save(self, tmp_path, monkeypatch):
+        # Stub streamlit before import
+        import importlib
+        monkeypatch.setitem(os.sys.modules, 'streamlit', __import__('types').SimpleNamespace(**{
+            'set_page_config': lambda **kwargs: None,
+            'markdown': lambda *a, **k: None,
+            'sidebar': __import__('types').SimpleNamespace(__enter__=lambda s: s, __exit__=lambda *a: False),
+            'selectbox': lambda *a, **k: '📊 Dashboard',
+            'image': lambda *a, **k: None,
+        }))
+        ap = importlib.import_module('admin_panel')
+        panel = ap.AdminPanel()
+        # Redirect config file
+        panel.config_file = tmp_path / '.env'
+        panel.config = {'A': '1', 'B': '2'}
+        panel._save_config()
+        # New instance loads same file
+        panel2 = ap.AdminPanel()
+        panel2.config_file = tmp_path / '.env'
+        panel2._load_config()
+        assert panel2.config['A'] == '1'
+        assert panel2.config['B'] == '2'
+
+    def test_get_system_stats(self, monkeypatch):
+        import importlib
+        monkeypatch.setitem(os.sys.modules, 'streamlit', __import__('types').SimpleNamespace(
+            set_page_config=lambda **k: None,
+            markdown=lambda *a, **k: None,
+        ))
+        ap = importlib.import_module('admin_panel')
+        panel = ap.AdminPanel()
+        stats = panel._get_system_stats()
+        assert set(['cpu_percent', 'memory_percent', 'disk_percent', 'uptime']).issubset(stats.keys())

--- a/tests/test_art.py
+++ b/tests/test_art.py
@@ -30,7 +30,9 @@ class TestArtModule:
             mock_response.data = [Mock()]
             mock_response.data[0].url = "https://example.com/image.png"
 
-            with patch('src.art.openai_client.images.generate', new=AsyncMock(return_value=mock_response)):
+            # Patch the module-level openai_client object directly
+            with patch('src.art.openai_client') as mock_client:
+                mock_client.images.generate = AsyncMock(return_value=mock_response)
                 result = await draw("openai", "A beautiful sunset")
 
                 assert result == "https://example.com/image.png"
@@ -72,6 +74,7 @@ class TestArtModule:
             "OPENAI_ENABLED": "True",
             "OPENAI_KEY": "test-key"
         }):
-            with patch('src.art.openai_client.images.generate', side_effect=Exception("API Error")):
+            with patch('src.art.openai_client') as mock_client:
+                mock_client.images.generate = AsyncMock(side_effect=Exception("API Error"))
                 with pytest.raises(Exception):
                     await draw("openai", "Test prompt")

--- a/tests/test_bot_commands.py
+++ b/tests/test_bot_commands.py
@@ -1,0 +1,17 @@
+import pytest
+from unittest.mock import AsyncMock
+
+
+@pytest.mark.asyncio
+async def test_setup_adds_cog():
+    from src.bot import setup, BotCommands
+    add_cog = AsyncMock()
+    class FakeBot:
+        async def add_cog(self, cog):
+            await add_cog(cog)
+
+    bot = FakeBot()
+    await setup(bot)
+    # Verifica que um Cog foi adicionado
+    assert add_cog.await_count == 1
+    assert isinstance(add_cog.await_args.args[0], BotCommands)

--- a/tests/test_client_ready.py
+++ b/tests/test_client_ready.py
@@ -1,0 +1,16 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+
+@pytest.mark.asyncio
+async def test_on_ready_sets_presence(monkeypatch):
+    from src.aclient import DiscordClient
+    c = DiscordClient()
+    # Fake user and methods (override internal connection user)
+    c._connection = SimpleNamespace(user=SimpleNamespace(id=1, __str__=lambda self='': 'bot'))
+    c.tree.sync = AsyncMock(return_value=[1,2,3,4])
+    c.change_presence = AsyncMock()
+    await c.on_ready()
+    c.tree.sync.assert_awaited()
+    c.change_presence.assert_awaited()

--- a/tests/test_commands_setup.py
+++ b/tests/test_commands_setup.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+def test_setup_commands_registers():
+    from src.aclient import DiscordClient
+    client = DiscordClient()
+    client.setup_commands()
+    cmds = client.tree.get_commands()
+    # Deve registrar pelo menos os 4 comandos definidos
+    names = {c.name for c in cmds}
+    assert {"chat","reset","persona","status"}.issubset(names)

--- a/tests/test_log_config.py
+++ b/tests/test_log_config.py
@@ -1,0 +1,16 @@
+import os
+from unittest.mock import patch
+
+
+def test_logger_file_toggle(tmp_path):
+    from importlib import reload
+    with patch.dict(os.environ, {
+        'LOG_TO_FILE': 'True',
+        'LOG_DIR': str(tmp_path),
+        'LOG_LEVEL': 'INFO'
+    }, clear=False):
+        import src.log as logmod
+        reload(logmod)
+        lg = logmod.setup_logger('src.test')
+        # Deve ter ao menos 1 handler (console) e provavelmente 2 (arquivo)
+        assert len(lg.handlers) >= 1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,42 @@
+import os
+import pytest
+from unittest.mock import patch
+
+
+class TestMainValidation:
+    @patch('src.log.logger')
+    def test_missing_token(self, mock_logger):
+        from importlib import reload
+        import main as main_mod
+        with patch('dotenv.load_dotenv', lambda *a, **k: None), \
+             patch.dict(os.environ, {}, clear=True):
+            reload(main_mod)
+            ok = main_mod.validate_environment()
+            assert ok is False
+            assert any('Missing required environment variables' in c[0][0] for c in mock_logger.error.call_args_list)
+
+    @patch('src.log.logger')
+    def test_invalid_token_format(self, mock_logger):
+        from importlib import reload
+        import main as main_mod
+        with patch.dict(os.environ, {"DISCORD_BOT_TOKEN": "abc123"}, clear=True):
+            reload(main_mod)
+            ok = main_mod.validate_environment()
+            assert ok is False
+            assert any('Invalid Discord token format' in c[0][0] for c in mock_logger.error.call_args_list)
+
+    @patch('src.log.logger')
+    def test_valid_env_and_providers(self, mock_logger):
+        from importlib import reload
+        import main as main_mod
+        token = 'MTM' + 'x'*60
+        env = {
+            'DISCORD_BOT_TOKEN': token,
+            'OPENAI_KEY': 'k1',
+            'CLAUDE_KEY': 'k2',
+            'GEMINI_KEY': 'k3',
+        }
+        with patch.dict(os.environ, env, clear=True):
+            reload(main_mod)
+            ok = main_mod.validate_environment()
+            assert ok is True

--- a/tests/test_message_utils_extra.py
+++ b/tests/test_message_utils_extra.py
@@ -1,0 +1,34 @@
+import pytest
+from unittest.mock import AsyncMock, Mock
+
+
+@pytest.mark.asyncio
+async def test_split_exact_boundary():
+    from utils.message_utils import send_split_message
+    channel = Mock()
+    channel.send = AsyncMock()
+    text = 'A' * 2000
+    await send_split_message(channel, text, 2000)
+    channel.send.assert_awaited_once_with(text)
+
+
+@pytest.mark.asyncio
+async def test_split_code_blocks_uneven():
+    from utils.message_utils import send_split_message
+    channel = Mock()
+    channel.send = AsyncMock()
+    text = "Here```CODE_START" + ("X" * 2100)
+    await send_split_message(channel, text, 1000)
+    # Should have sent multiple chunks
+    assert channel.send.await_count >= 3
+
+
+@pytest.mark.asyncio
+async def test_split_multiple_blocks():
+    from utils.message_utils import send_split_message
+    channel = Mock()
+    channel.send = AsyncMock()
+    text = "pre```code1```mid```code2```post"
+    await send_split_message(channel, text, 10)
+    # Several chunks expected
+    assert channel.send.await_count >= 3

--- a/tests/test_personas_extra.py
+++ b/tests/test_personas_extra.py
@@ -1,0 +1,27 @@
+import pytest
+
+
+def test_personas_helpers():
+    from src import personas as p
+    # get_all_personas includes restritas
+    allp = p.get_all_personas()
+    assert 'helpful' in allp and 'jailbreak' in allp
+    # info + description
+    info = p.get_persona_info('helpful')
+    assert isinstance(info, dict)
+    assert p.get_persona_description('helpful')
+    # inválida
+    assert p.get_persona_info('nope') is None
+    assert p.get_persona_description('nope') == 'Personalidade não encontrada'
+    # restrições
+    assert p.is_restricted_persona('jailbreak') is True
+    assert p.is_restricted_persona('helpful') is False
+    # can_use_persona
+    assert p.can_use_persona('jailbreak', is_admin=False) is False
+    assert p.can_use_persona('jailbreak', is_admin=True) is True
+    assert p.can_use_persona('helpful', is_admin=False) is True
+    # list_personas_for_user
+    pub = p.list_personas_for_user(False)
+    adm = p.list_personas_for_user(True)
+    assert 'helpful' in pub and 'jailbreak' not in pub
+    assert 'jailbreak' in adm

--- a/tests/test_providers_extra.py
+++ b/tests/test_providers_extra.py
@@ -1,0 +1,21 @@
+import pytest
+
+
+def test_convert_messages_to_prompt():
+    from src.providers import ProviderManager
+    pm = ProviderManager()
+    messages = [
+        {"role": "system", "content": "S"},
+        {"role": "user", "content": "U"},
+        {"role": "assistant", "content": "A"},
+    ]
+    out = pm._convert_messages_to_prompt(messages)
+    assert 'System: S' in out and 'User: U' in out and 'Assistant: A' in out
+
+
+def test_get_provider_status_and_model_setter():
+    from src.providers import ProviderManager
+    pm = ProviderManager()
+    status = pm.get_provider_status()
+    assert set(['current_provider','current_model','available_providers','models_count']).issubset(status.keys())
+    assert pm.set_current_model('non-existent') is False

--- a/tests/test_providers_impl.py
+++ b/tests/test_providers_impl.py
@@ -1,0 +1,104 @@
+import os
+import types
+import pytest
+from unittest.mock import patch
+
+
+@pytest.mark.asyncio
+async def test_openai_response_success(monkeypatch):
+    from src.providers import ProviderManager
+
+    # Fake openai module
+    mod = types.SimpleNamespace()
+    async def create(**kwargs):
+        return types.SimpleNamespace(choices=[types.SimpleNamespace(message=types.SimpleNamespace(content='OK'))])
+    mod.AsyncClient = lambda api_key=None: types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=create))
+    )
+
+    with patch.dict(os.environ, {"OPENAI_KEY": "k"}, clear=False), \
+         patch.dict('sys.modules', {'openai': mod}):
+        pm = ProviderManager()
+        out = await pm._get_openai_response([
+            {"role":"user","content":"hi"}
+        ])
+        assert out == 'OK'
+
+
+@pytest.mark.asyncio
+async def test_openai_missing_key():
+    from src.providers import ProviderManager
+    with patch.dict(os.environ, {}, clear=True):
+        pm = ProviderManager()
+        out = await pm._get_openai_response([])
+    assert 'OpenAI' in out or 'Openai' in out
+
+
+@pytest.mark.asyncio
+async def test_claude_response_success(monkeypatch):
+    from src.providers import ProviderManager
+    mod = types.SimpleNamespace()
+    async def create(**kwargs):
+        return types.SimpleNamespace(content=[types.SimpleNamespace(text='CLAUDE')])
+    mod.AsyncClient = lambda api_key=None: types.SimpleNamespace(messages=types.SimpleNamespace(create=create))
+
+    with patch.dict(os.environ, {"CLAUDE_KEY": "k"}, clear=False), \
+         patch.dict('sys.modules', {'anthropic': mod}):
+        pm = ProviderManager()
+        out = await pm._get_claude_response([
+            {"role":"system","content":"s"}, {"role":"user","content":"u"}
+        ])
+        assert out == 'CLAUDE'
+
+
+@pytest.mark.asyncio
+async def test_gemini_response_success(monkeypatch):
+    from src.providers import ProviderManager
+
+    # Fake google.generativeai
+    class FakeModel:
+        def __init__(self, name):
+            self.name = name
+        async def generate_content_async(self, prompt):
+            return types.SimpleNamespace(text='GEMINI')
+    fake_genai = types.SimpleNamespace(
+        configure=lambda api_key=None: None,
+        GenerativeModel=FakeModel
+    )
+
+    with patch.dict(os.environ, {"GEMINI_KEY": "k"}, clear=False), \
+         patch.dict('sys.modules', {'google.generativeai': fake_genai}):
+        pm = ProviderManager()
+        out = await pm._get_gemini_response([
+            {"role":"user","content":"u"}
+        ])
+        assert out == 'GEMINI'
+
+
+@pytest.mark.asyncio
+async def test_grok_fallback(monkeypatch):
+    from src.providers import ProviderManager
+    pm = ProviderManager()
+    # ensure fallback path returns string
+    out = await pm._get_grok_response([
+        {"role":"user","content":"u"}
+    ])
+    assert isinstance(out, str)
+
+
+@pytest.mark.asyncio
+async def test_openai_response_exception(monkeypatch):
+    from src.providers import ProviderManager
+    # Fake openai raising exception
+    class BadClient:
+        class chat:
+            class completions:
+                @staticmethod
+                async def create(**kwargs):
+                    raise RuntimeError('boom')
+    mod = types.SimpleNamespace(AsyncClient=lambda api_key=None: BadClient)
+    with patch.dict(os.environ, {"OPENAI_KEY": "k"}, clear=True), \
+         patch.dict('sys.modules', {'openai': mod}):
+        pm = ProviderManager()
+        out = await pm._get_openai_response([{"role":"user","content":"hi"}])
+        assert 'Erro' in out or 'erro' in out

--- a/tests/test_start_admin.py
+++ b/tests/test_start_admin.py
@@ -1,0 +1,48 @@
+import os
+import pytest
+from unittest.mock import patch, Mock
+
+
+class TestStartAdmin:
+    def test_check_requirements_ok(self, monkeypatch):
+        import importlib
+        monkeypatch.setitem(os.sys.modules, 'streamlit', Mock())
+        monkeypatch.setitem(os.sys.modules, 'psutil', Mock())
+        monkeypatch.setitem(os.sys.modules, 'pandas', Mock())
+        sa = importlib.import_module('start_admin')
+        assert sa.check_requirements() is True
+
+    def test_check_requirements_missing(self, monkeypatch):
+        import importlib
+        import builtins
+        sa = importlib.import_module('start_admin')
+        real_import = builtins.__import__
+        def fake_import(name, *a, **k):
+            if name in ('streamlit', 'psutil', 'pandas'):
+                raise ImportError('missing')
+            return real_import(name, *a, **k)
+        with patch('builtins.__import__', side_effect=fake_import):
+            assert sa.check_requirements() is False
+
+    def test_check_bot_config(self, tmp_path, monkeypatch):
+        import importlib
+        sa = importlib.import_module('start_admin')
+        monkeypatch.chdir(tmp_path)
+        # No .env
+        assert sa.check_bot_config() is False
+        # With .env and token
+        (tmp_path / '.env').write_text('DISCORD_BOT_TOKEN=abc12345678901234567890')
+        assert sa.check_bot_config() is True
+
+    def test_start_admin_panel_spawns(self, tmp_path, monkeypatch):
+        import importlib
+        sa = importlib.import_module('start_admin')
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / 'admin_panel.py').write_text('print("ok")')
+        with patch('start_admin.subprocess.Popen') as mock_popen, \
+             patch('start_admin.webbrowser.open') as mock_open, \
+             patch('start_admin.time.sleep') as mock_sleep:
+            proc = Mock()
+            proc.wait = Mock(side_effect=KeyboardInterrupt)
+            mock_popen.return_value = proc
+            assert sa.start_admin_panel() is True

--- a/tests/test_start_admin.py
+++ b/tests/test_start_admin.py
@@ -43,6 +43,7 @@ class TestStartAdmin:
              patch('start_admin.webbrowser.open') as mock_open, \
              patch('start_admin.time.sleep') as mock_sleep:
             proc = Mock()
-            proc.wait = Mock(side_effect=KeyboardInterrupt)
+            # Simula término limpo do processo
+            proc.wait = Mock(return_value=0)
             mock_popen.return_value = proc
             assert sa.start_admin_panel() is True


### PR DESCRIPTION
Resumo\n- Configura pytest-cov e .coveragerc.\n- Adiciona testes para main, admin_panel, start_admin, providers (com stubs),\n  aclient on_ready/commands, personas, message_utils e logging.\n- Alinha testes de arte ao cliente OpenAI em nível de módulo.\n\nValidação\n- uv run -- pytest: 67 passed.\n- Cobertura elevada para src + main (detalhes podem variar por ambiente).\n\nPróximos passos\n- Opcional: habilitar job no GitHub Actions com UV + pytest-cov e piso de cobertura.\n